### PR TITLE
Fix some edge cases when running in ci environment

### DIFF
--- a/src/Command/Lint.php
+++ b/src/Command/Lint.php
@@ -92,8 +92,9 @@ class Lint extends Command
             while (!feof(STDIN)) {
                 $template .= fread(STDIN, 1024);
             }
-
-            return $this->display([$this->validate($template)], $format);
+            if (ftell(STDIN) !== 0) {
+                return $this->display([$this->validate($template)], $format);
+            }
         }
 
         $files   = $this->getFiles($this->argument('filename'), $this->option('file'), $this->option('directory'));


### PR DESCRIPTION
Fallback to automatic file detection in lint command when stdin pointer position is 0 after reaching EOF